### PR TITLE
Update ssh daemon to start with inet6

### DIFF
--- a/lib/nerves_ssh.ex
+++ b/lib/nerves_ssh.ex
@@ -202,7 +202,8 @@ defmodule NervesSSH do
       {:system_dir, system_dir(opts)},
       {:shell, {Elixir.IEx, :start, [iex_opts]}},
       {:exec, &start_exec/3},
-      {:subsystems, subsystems(opts)}
+      {:subsystems, subsystems(opts)},
+      :inet6
     ]
 
     case {:ssh.daemon(port, options), force?} do


### PR DESCRIPTION
Fixes #4 

I tested this on a device that doesn't have ipv6 and it still worked, so i think it's safe...