### PR TITLE
Cool off after daemon crash; handle terminate/2 not being called

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,8 +1,0 @@
-[
-  # dialyzer doesn't like start_daemon/3 wrapping the :ssh.daemon call
-  # and can only guess the error type of the function. For now, let's
-  # just ignore in specific places
-  {"lib/nerves_ssh.ex", :pattern_match_cov, 73},
-  {"lib/nerves_ssh.ex", :pattern_match_cov, 87},
-  {"lib/nerves_ssh.ex", :extra_range, 176}
-]

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -46,7 +46,7 @@ defmodule NervesSSH.Options do
   def new(opts \\ []) do
     # if a key is present with nil value, the default will
     # not be applied in the struct. So remove keys that
-    # have a nil value so defaults get set appropiately
+    # have a nil value so defaults get set appropriately
     opts = Enum.reject(opts, fn {_k, v} -> is_nil(v) end)
 
     struct(__MODULE__, opts)

--- a/mix.exs
+++ b/mix.exs
@@ -46,8 +46,7 @@ defmodule NervesSSH.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
-      ignore_warnings: ".dialyzer_ignore.exs"
+      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs]
     ]
   end
 

--- a/test/nerves_ssh/daemon_test.exs
+++ b/test/nerves_ssh/daemon_test.exs
@@ -41,4 +41,40 @@ defmodule NervesSSH.DaemonTest do
 
     assert {:ok, "4", 0} == ssh_run("2 + 2")
   end
+
+  test "stopping and starting the application" do
+    assert {:ok, ":running_at_start?", 0} == ssh_run(":running_at_start?")
+
+    assert :ok == Application.stop(:nerves_ssh)
+    Process.sleep(500)
+    assert {:error, :econnrefused} == ssh_run(":really_stopped?")
+
+    assert :ok == Application.start(:nerves_ssh)
+    assert {:ok, ":started_again?", 0} == ssh_run(":started_again?")
+  end
+
+  test "starting the application after terminate wasn't called" do
+    assert :ok == Application.stop(:nerves_ssh)
+
+    # Start a server up manually to simulate terminate not being called
+    # to shut down the server.
+    {:ok, _pid} =
+      GenServer.start(
+        NervesSSH.Daemon,
+        NervesSSH.Options.new(
+          user_passwords: [{"test_user", "not_the_right_password"}],
+          port: 4022,
+          system_dir: :code.priv_dir(:nerves_ssh)
+        )
+      )
+
+    # Verify that the old server has started and that it won't accept
+    # the test credentials.
+    assert {:error, 'Unable to connect using the available authentication methods'} ==
+             ssh_run(":started_again?")
+
+    # Start the real server up. It should kill our old one.
+    assert :ok == Application.start(:nerves_ssh)
+    assert {:ok, ":started_again?", 0} == ssh_run(":started_again?")
+  end
 end

--- a/test/nerves_ssh/daemon_test.exs
+++ b/test/nerves_ssh/daemon_test.exs
@@ -31,9 +31,9 @@ defmodule NervesSSH.DaemonTest do
     state = :sys.get_state(NervesSSH.Daemon)
     assert {:ok, "2", 0} == ssh_run("1 + 1")
 
-    # Simulate sshd failure and wait for restart
+    # Simulate sshd failure. restart
     Process.exit(state.sshd, :kill)
-    :timer.sleep(10)
+    :timer.sleep(800)
 
     # Test recovery
     new_state = :sys.get_state(NervesSSH.Daemon)

--- a/test/nerves_ssh/daemon_test.exs
+++ b/test/nerves_ssh/daemon_test.exs
@@ -46,10 +46,11 @@ defmodule NervesSSH.DaemonTest do
     assert {:ok, ":running_at_start?", 0} == ssh_run(":running_at_start?")
 
     assert :ok == Application.stop(:nerves_ssh)
-    Process.sleep(500)
+    Process.sleep(250)
     assert {:error, :econnrefused} == ssh_run(":really_stopped?")
 
     assert :ok == Application.start(:nerves_ssh)
+    Process.sleep(250)
     assert {:ok, ":started_again?", 0} == ssh_run(":started_again?")
   end
 
@@ -75,6 +76,7 @@ defmodule NervesSSH.DaemonTest do
 
     # Start the real server up. It should kill our old one.
     assert :ok == Application.start(:nerves_ssh)
+    Process.sleep(250)
     assert {:ok, ":started_again?", 0} == ssh_run(":started_again?")
   end
 end


### PR DESCRIPTION
This adds tests for the cases where the SSH daemon crashes or NervesSSH.Daemon
crashes.  It simplifies the existing code to the minimum of what's needed to
recover and adds a cool off period for the system to recover after whatever
caused the crashes to happen.

As a note, it's unknown what causes this to happen. Since it was triggered via
some kind of fuzzing of the ssh port (not reproducible by me), the system may
have been under some stress. Having a short cool off period seems like a
reasonable thing to do. The previous workaround retried up to 10 times and
actively tried closing servers on the ssh port.  That apparently worked, but I
believe that stopping the server and waiting would have worked too, and this
simplifies the code.