### PR TITLE
Add NervesSSH.info/0

### DIFF
--- a/lib/nerves_ssh.ex
+++ b/lib/nerves_ssh.ex
@@ -8,4 +8,12 @@ defmodule NervesSSH do
   """
   @spec configuration :: NervesSSH.Options.t()
   defdelegate configuration(), to: NervesSSH.Daemon
+
+  @doc """
+  Return information on the running ssh daemon.
+
+  See [ssh.daemon_info/1](http://erlang.org/doc/man/ssh.html#daemon_info-1).
+  """
+  @spec info() :: {:ok, [:ssh.daemon_info_tuple()]} | {:error, :bad_daemon_ref}
+  defdelegate info(), to: NervesSSH.Daemon
 end

--- a/lib/nerves_ssh/daemon.ex
+++ b/lib/nerves_ssh/daemon.ex
@@ -32,6 +32,16 @@ defmodule NervesSSH.Daemon do
     GenServer.call(__MODULE__, :configuration)
   end
 
+  @doc """
+  Return information on the running ssh daemon.
+
+  See [ssh.daemon_info/1](http://erlang.org/doc/man/ssh.html#daemon_info-1).
+  """
+  @spec info() :: {:ok, [:ssh.daemon_info_tuple()]} | {:error, :bad_daemon_ref}
+  def info() do
+    GenServer.call(__MODULE__, :info)
+  end
+
   @impl true
   def init(opts) do
     # Make sure we can attempt SSH daemon cleanup if
@@ -52,6 +62,10 @@ defmodule NervesSSH.Daemon do
   @impl true
   def handle_call(:configuration, _from, state) do
     {:reply, state.opts, state}
+  end
+
+  def handle_call(:info, _from, state) do
+    {:reply, :ssh.daemon_info(state.sshd), state}
   end
 
   @impl true


### PR DESCRIPTION
This returns the result of `:ssh.daemon_info/1` and is useful for
debugging server issues.