### PR TITLE
Detect out-of-date config.exs at compile time

### DIFF
--- a/lib/nerves_ssh/application.ex
+++ b/lib/nerves_ssh/application.ex
@@ -5,6 +5,21 @@ defmodule NervesSSH.Application do
 
   alias NervesSSH.Options
 
+  if Application.get_all_env(:nerves_ssh) == [] and
+       Application.get_all_env(:nerves_firmware_ssh) != [] do
+    raise """
+    :nerves_ssh isn't configured, but :nerves_firmware_ssh is.
+
+    This is probably not right. If you recently upgraded to :nerves_ssh or
+    a library that uses it like :nerves_pack, you'll need to edit your config.exs
+    and rename references to :nerves_firmware_ssh to :nerves_ssh. See
+    https://hexdocs.pm/nerves_ssh/readme.html#configuration.
+
+    To use both :nerves_ssh and :nerves_firmware_ssh simultaneously, supply a
+    :nerves_ssh config to bypass this error.
+    """
+  end
+
   @impl Application
   def start(_type, _args) do
     children =


### PR DESCRIPTION
When upgrading from `:nerves_firmware_ssh` to `:nerves_ssh`, it's easy
to forget to modify the `config.exs`. This adds a big compile-time error
to tell you what to do.