### PR TITLE
Improve instructions for upgrading from nerves_firmware_ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,23 +146,28 @@ config :nerves_ssh,
 If you are migrating from `:nerves_firmware_ssh`, or updating to `:nerves_pack
 >= 0.4.0`, you will need to make a few changes to your existing project.
 
-1. Change all `:nerves_firmware_ssh` config values to `:nerves_ssh`. A command
+1. Generate a `upload.sh` script by running `mix firmware.gen.script` (if you
+   don't already have one)
+   - This is necessary because you will no longer have access to your old
+     `mix upload` command because `nerves_firmware_ssh` is being removed from
+     the project.
+2. Change all `:nerves_firmware_ssh` config values to `:nerves_ssh`. A command
    like this would probably do the trick:
 
     ```sh
     grep -RIl nerves_firmware_ssh config/ | xargs sed -i 's/nerves_firmware_ssh/nerves_ssh/g'
     ```
 
-2. Compile your new firmware that includes `:nerves_ssh` (or updated
+3. Compile your new firmware that includes `:nerves_ssh` (or updated
    `:nerves_pack`)
     * **NOTE** Compiling your new firmware for the first time will generate a
       warning about the old `upload.sh` script still being around. You can
       ignore that **this one time** because you will need it for uploading to an
       existing device still using port 8989.
-3. Upload your new firmware with `:nerves_ssh` using the **_old_** `upload.sh`
+4. Upload your new firmware with `:nerves_ssh` using the **_old_** `upload.sh`
    script (or whatever other method you have been using for OTA firmware
    updates)
-4. After the new firmware with `:nerves_ssh` is on the device, then you'll need
+5. After the new firmware with `:nerves_ssh` is on the device, then you'll need
    to generate the new `upload.sh` script with `mix firmware.gen.script`, or see
    [SSHSubsystemFwup](https://hexdocs.pm/ssh_subsystem_fwup/readme.html) for
    other supported options


### PR DESCRIPTION
At first I didn't understand the error I was getting when I was trying to use `mix upload` or `upload.sh` from nerves_ssh.