### PR TITLE
Force Erlang evaluation when specified

### DIFF
--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -167,13 +167,13 @@ defmodule NervesSSH.Options do
   defp shell_opts(%{shell: :elixir, iex_opts: iex_opts}),
     do: [{:shell, {Elixir.IEx, :start, [iex_opts]}}]
 
-  defp shell_opts(%{shell: :erlang}), do: []
+  defp shell_opts(%{shell: :erlang}), do: [{:shell, {:shell, :start, []}}]
   defp shell_opts(%{shell: :lfe}), do: [{:shell, {:lfe_shell, :start, []}}]
   defp shell_opts(%{shell: :disabled}), do: [shell: :disabled]
 
   if @otp >= 23 do
     defp exec_opts(%{exec: :elixir}), do: [exec: {:direct, &NervesSSH.Exec.run_elixir/1}]
-    defp exec_opts(%{exec: :erlang}), do: []
+    defp exec_opts(%{exec: :erlang}), do: [exec: {:direct, &NervesSSH.Exec.run_erlang/1}]
     defp exec_opts(%{exec: :lfe}), do: [exec: {:direct, &NervesSSH.Exec.run_lfe/1}]
     defp exec_opts(%{exec: :disabled}), do: [exec: :disabled]
   else
@@ -181,8 +181,8 @@ defmodule NervesSSH.Options do
     defp exec_opts(%{exec: :elixir}),
       do: [exec: fn cmd -> spawn(__MODULE__, :run_exec, [NervesSSH.Exec, :run_elixir, [cmd]]) end]
 
+    # Don't support :lfe and :erlang the old way
     defp exec_opts(%{exec: :erlang}), do: []
-    # Don't support :lfe the old way
     defp exec_opts(%{exec: :lfe}), do: []
     defp exec_opts(%{exec: :disabled}), do: [exec: :disabled]
 

--- a/test/nerves_ssh_test.exs
+++ b/test/nerves_ssh_test.exs
@@ -117,6 +117,12 @@ defmodule NervesSshTest do
   end
 
   @tag :has_good_sshd_exec
+  test "erlang exec works" do
+    start_supervised!({NervesSSH, Map.put(@nerves_ssh_config, :exec, :erlang)})
+    assert {:ok, "3", 0} == ssh_run("1 + 2.", @username_login)
+  end
+
+  @tag :has_good_sshd_exec
   test "lfe exec works" do
     start_supervised!({NervesSSH, Map.put(@nerves_ssh_config, :exec, :lfe)})
     assert {:ok, "2", 0} == ssh_run("(+ 1 1)", @username_login)


### PR DESCRIPTION
The ssh daemon's exec logic determines whether to run the erlang
evaluator based on whether the shell was specified and exec was not.
Adding an evaluator here isn't much code and ensures that the Erlang
evaluator is called.
