### PR TITLE
Use :ssh_file.decode/2 with OTP >= 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ install_system_deps: &install_system_deps
 jobs:
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.1-erlang-24.0-alpine-3.13.3
+      - image: hexpm/elixir:1.12.1-erlang-24.0.2-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -193,7 +193,7 @@ defmodule NervesSSH.Options do
   end
 
   defp key_cb_opts(opts) do
-    keys = Enum.flat_map(opts.authorized_keys, &:public_key.ssh_decode(&1, :auth_keys))
+    keys = Enum.flat_map(opts.authorized_keys, &decode_key/1)
 
     [key_cb: {NervesSSH.Keys, [authorized_keys: keys]}]
   end
@@ -275,5 +275,13 @@ defmodule NervesSSH.Options do
       {:ok, _} -> true
       _ -> false
     end
+  end
+
+  # :public_key.ssh_decode/2 was deprecated in OTP 24 and will be removed in OTP 26.
+  # :ssh_file.decode/2 was introduced in OTP 24
+  if @otp >= 24 do
+    defp decode_key(key), do: :ssh_file.decode(key, :auth_keys)
+  else
+    defp decode_key(key), do: :public_key.ssh_decode(key, :auth_keys)
   end
 end


### PR DESCRIPTION
OTP 24 now has a deprecation warning for how decoding public keys is handled. This adds the new supported decode function, but doesn't get ride of the warning (I'm not sure how to do that?

```
> nerves_ssh √ % mix test                                                                                                                                                                                                                   ssh-decode
Compiling 1 file (.ex)
warning: :public_key.ssh_decode/2 is deprecated. It will be removed in OTP 26. Use ssh_file:decode/2 instead
  lib/nerves_ssh/options.ex:284: NervesSSH.Options.decode_key/2
```