### PR TITLE
Fix handling of scp destination

### DIFF
--- a/lib/nerves_ssh/scp.ex
+++ b/lib/nerves_ssh/scp.ex
@@ -157,12 +157,12 @@ defmodule NervesSSH.SCP do
   end
 
   # dest_path can be a folder or a full pathname
-  def combine_paths(dest_path, file_name) do
-    if Path.basename(dest_path) == Path.basename(file_name) do
-      {:ok, dest_path}
+  defp combine_paths(dest_path, source_path) do
+    if File.dir?(dest_path) do
+      dest_filename = Path.basename(source_path)
+      {:ok, Path.join(dest_path, dest_filename)}
     else
-      File.mkdir_p!(dest_path)
-      {:ok, Path.join(dest_path, file_name)}
+      {:ok, dest_path}
     end
   end
 end


### PR DESCRIPTION
This fixes the scp logic to match my experience with commandline scp
(there might be more to it). The logic is this:

1. If the destination is a directory, put the file in that directory
   with the same name as the source file
2. If the destination is a file or doesn't exist, then overwrite it with
   the contents of the source file
