### PR TITLE
Support changing user passwords at runtime

### DIFF
--- a/lib/nerves_ssh.ex
+++ b/lib/nerves_ssh.ex
@@ -70,6 +70,25 @@ defmodule NervesSSH do
     GenServer.call(__MODULE__, {:remove_authorized_key, key})
   end
 
+  @doc """
+  Add a user credential to the SSH daemon
+
+  Setting password to `""` or `nil` will effectively be passwordless
+  authentication for this user
+  """
+  @spec add_user(String.t(), String.t() | nil) :: :ok
+  def add_user(user, password) do
+    GenServer.call(__MODULE__, {:add_user, [user, password]})
+  end
+
+  @doc """
+  Remove a user credential from the SSH daemon
+  """
+  @spec remove_user(String.t()) :: :ok
+  def remove_user(user) do
+    GenServer.call(__MODULE__, {:remove_user, [user]})
+  end
+
   @impl true
   def init(opts) do
     # Make sure we can attempt SSH daemon cleanup if
@@ -119,6 +138,12 @@ defmodule NervesSSH do
     state =
       update_in(state.opts, &apply(Options, fun, [&1, key]))
       |> try_save_authorized_keys()
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({fun, args}, _from, state) when fun in [:add_user, :remove_user] do
+    state = update_in(state.opts, &apply(Options, fun, [&1 | args]))
 
     {:reply, :ok, state}
   end

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -155,6 +155,23 @@ defmodule NervesSSH.Options do
     end
   end
 
+  @doc """
+  Add user credential to SSH options
+  """
+  @spec add_user(t(), String.t(), String.t() | nil) :: t()
+  def add_user(opts, user, password)
+      when is_binary(user) and (is_binary(password) or is_nil(password)) do
+    update_in(opts.user_passwords, &Enum.uniq_by([{user, password} | &1], fn {u, _} -> u end))
+  end
+
+  @doc """
+  Remove user credential from SSH options
+  """
+  @spec remove_user(t(), String.t()) :: t()
+  def remove_user(opts, user) do
+    update_in(opts.user_passwords, &for({u, _} = k <- &1, u != user, do: k))
+  end
+
   defp base_opts() do
     [
       inet: :inet6,
@@ -224,7 +241,7 @@ defmodule NervesSSH.Options do
         {to_charlist(user), to_charlist(password)}
       end
 
-    [user_passwords: passes]
+    [user_passwords: passes, pwdfun: &NervesSSH.UserPasswords.check/4]
   end
 
   defp authentication_daemon_opts(opts) do

--- a/lib/nerves_ssh/user_passwords.ex
+++ b/lib/nerves_ssh/user_passwords.ex
@@ -1,0 +1,37 @@
+defmodule NervesSSH.UserPasswords do
+  @moduledoc """
+  Default module used for checking User/Password combinations
+
+  This will allow 3 attempts to login with a username and password
+  and then send SSH_MSG_DISCONNECT
+  """
+
+  require Logger
+
+  @spec check(:erlang.string(), :erlang.string(), :ssh.ip_port(), :undefined | non_neg_integer()) ::
+          boolean() | :disconnect | {boolean, non_neg_integer()}
+  def check(user, password, ip, :undefined), do: check(user, password, ip, 0)
+
+  def check(user, pwd, ip_port, attempt) do
+    attempt = attempt + 1
+
+    is_authorized?(user, pwd) || maybe_disconnect(attempt, user, ip_port)
+  end
+
+  defp is_authorized?(user, pwd) do
+    NervesSSH.configuration().user_passwords
+    |> Enum.find_value(false, fn {u, p} ->
+      "#{u}" == "#{user}" and "#{p}" == "#{pwd}"
+    end)
+  catch
+    :exit, _ ->
+      false
+  end
+
+  defp maybe_disconnect(attempt, user, {ip, port}) when attempt >= 3 do
+    Logger.info("[NervesSSH] Rejected #{user}@#{:inet.ntoa(ip)}:#{port} after 3 failed attempts")
+    :disconnect
+  end
+
+  defp maybe_disconnect(attempt, _, _), do: {false, attempt}
+end

--- a/test/nerves_ssh/options_test.exs
+++ b/test/nerves_ssh/options_test.exs
@@ -104,6 +104,30 @@ defmodule NervesSSH.OptionsTest do
              [{'alice', 'password'}, {'bob', '1234'}]
   end
 
+  test "adding user/password to options" do
+    opts = Options.new()
+
+    assert opts.user_passwords == []
+
+    updated =
+      opts
+      |> Options.add_user("jon", "wat")
+      |> Options.add_user("frank", "")
+      |> Options.add_user("connor", nil)
+
+    assert updated.user_passwords == [
+             {"connor", nil},
+             {"frank", ""},
+             {"jon", "wat"}
+           ]
+  end
+
+  test "removing user from options" do
+    opts = Options.new(user_passwords: [{"howdy", "partner"}])
+
+    assert Options.remove_user(opts, "howdy").user_passwords == []
+  end
+
   test "adding daemon options" do
     opts = Options.new(daemon_option_overrides: [my_option: 1])
     daemon_options = Options.daemon_options(opts)

--- a/test/nerves_ssh_test.exs
+++ b/test/nerves_ssh_test.exs
@@ -267,4 +267,21 @@ defmodule NervesSshTest do
 
     assert {:error, _} = ssh_run("1 + 1", @key_login)
   end
+
+  @tag :has_good_sshd_exec
+  test "adding user/password at runtime" do
+    start_supervised!({NervesSSH, nerves_ssh_config()})
+    refute {:ok, "2", 0} == ssh_run("1 + 1", user: 'jon', password: 'wat')
+    NervesSSH.add_user("jon", "wat")
+    assert {:ok, "2", 0} == ssh_run("1 + 1", user: 'jon', password: 'wat')
+  end
+
+  @tag :has_good_sshd_exec
+  test "removing user/password at runtime" do
+    start_supervised!({NervesSSH, nerves_ssh_config()})
+    login = Keyword.drop(@username_login, [:user_dir])
+    assert {:ok, "2", 0} == ssh_run("1 + 1", login)
+    NervesSSH.remove_user("#{login[:user]}")
+    refute {:ok, "2", 0} == ssh_run("1 + 1", login)
+  end
 end


### PR DESCRIPTION
For #62

This starts convenience support for altering User/Password combinations at runtime. I don't know if this fully solves the issue since changes done at runtime are lost on reboots/daemon restart. But this is at least a start.