### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add --no-cache build-base linux-headers libmnl-dev libnl3-dev git openssh
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.1-erlang-24.2-alpine-3.15.0
+      - image: hexpm/elixir:1.13.4-erlang-25.0.1-alpine-3.15.4
     <<: *defaults
     steps:
       - checkout
@@ -44,9 +44,20 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.4-erlang-24.3.4-alpine-3.15.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.7-alpine-3.14.2
+      - image: hexpm/elixir:1.12.3-erlang-24.3.4-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -57,7 +68,7 @@ jobs:
 
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4.13-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -81,6 +92,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -116,7 +116,7 @@ defmodule NervesSSH.Options do
   Load authorized keys from the authorized_keys file
   """
   @spec load_authorized_keys(t()) :: t()
-  def load_authorized_keys(opts) do
+  def load_authorized_keys(opts) when is_struct(opts) do
     case File.read(authorized_keys_path(opts)) do
       {:ok, str} ->
         from_file = String.split(str, "\n", trim: true)

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule NervesSSH.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs],
       plt_add_apps: [:lfe]
     ]
   end

--- a/test/nerves_ssh/options_test.exs
+++ b/test/nerves_ssh/options_test.exs
@@ -4,10 +4,17 @@ defmodule NervesSSH.OptionsTest do
 
   alias NervesSSH.Options
 
+  decode_fun =
+    if String.to_integer(System.otp_release()) >= 24 do
+      &:ssh_file.decode/2
+    else
+      &:public_key.ssh_decode/2
+    end
+
   @rsa_public_key String.trim(File.read!("test/fixtures/good_user_dir/id_rsa.pub"))
-  @rsa_public_key_decoded elem(hd(:public_key.ssh_decode(@rsa_public_key, :auth_keys)), 0)
+  @rsa_public_key_decoded elem(hd(decode_fun.(@rsa_public_key, :auth_keys)), 0)
   @ecdsa_public_key "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBK9UY+mjrTRdnO++HmV3TbSJkTkyR1tEqz0dITc3TD4l+WWIqvbOtUg2MN/Tg+bWtvD6aEX7/fjCGTxwe7BmaoI="
-  @ecdsa_public_key_decoded elem(hd(:public_key.ssh_decode(@ecdsa_public_key, :auth_keys)), 0)
+  @ecdsa_public_key_decoded elem(hd(decode_fun.(@ecdsa_public_key, :auth_keys)), 0)
 
   defp assert_options(got, expected) do
     for option <- expected do

--- a/test/nerves_ssh_test.exs
+++ b/test/nerves_ssh_test.exs
@@ -1,6 +1,13 @@
 defmodule NervesSshTest do
   use ExUnit.Case, async: true
 
+  decode_fun =
+    if String.to_integer(System.otp_release()) >= 24 do
+      &:ssh_file.decode/2
+    else
+      &:public_key.ssh_decode/2
+    end
+
   @username_login [
     user: 'test_user',
     password: 'password',
@@ -10,7 +17,7 @@ defmodule NervesSshTest do
   @base_ssh_port 4022
   @rsa_public_key String.trim(File.read!("test/fixtures/good_user_dir/id_rsa.pub"))
   @ed25519_public_key String.trim(File.read!("test/fixtures/good_user_dir/id_ed25519.pub"))
-  @ed25519_public_key_decoded elem(hd(:public_key.ssh_decode(@ed25519_public_key, :auth_keys)), 0)
+  @ed25519_public_key_decoded elem(hd(decode_fun.(@ed25519_public_key, :auth_keys)), 0)
 
   defp nerves_ssh_config() do
     NervesSSH.Options.with_defaults(


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions

d1e9a0ad8b92739364c1697dc66f2fc323e04918 makes no sense to me, but that is what is required to pass the specs. I can't see anyway an atom might be returned rather than an options struct