### PR TITLE
Allow running multiple SSH daemons

### DIFF
--- a/lib/nerves_ssh.ex
+++ b/lib/nerves_ssh.ex
@@ -29,20 +29,16 @@ defmodule NervesSSH do
   defp via_name(name), do: {:via, Registry, {NervesSSH.Registry, name}}
 
   @doc false
-  @spec start_link(Options.t() | {atom(), Options.t()}) :: GenServer.on_start()
-  def start_link({name, %Options{} = opts}) do
-    GenServer.start_link(__MODULE__, %{opts | name: name}, name: via_name(name))
-  end
-
+  @spec start_link(Options.t()) :: GenServer.on_start()
   def start_link(%Options{} = opts) do
-    GenServer.start_link(__MODULE__, %{opts | name: :default}, name: via_name(:default))
+    GenServer.start_link(__MODULE__, opts, name: via_name(opts.name))
   end
 
   @doc """
   Read the configuration options
   """
   @spec configuration :: Options.t()
-  def configuration(name \\ :default) do
+  def configuration(name \\ NervesSSH) do
     GenServer.call(via_name(name), :configuration)
   end
 
@@ -52,7 +48,7 @@ defmodule NervesSSH do
   See [ssh.daemon_info/1](http://erlang.org/doc/man/ssh.html#daemon_info-1).
   """
   @spec info() :: {:ok, keyword()} | {:error, :bad_daemon_ref}
-  def info(name \\ :default) do
+  def info(name \\ NervesSSH) do
     GenServer.call(via_name(name), :info)
   end
 
@@ -62,7 +58,7 @@ defmodule NervesSSH do
   This will also attempt to save the key in `{USER_DIR}/authorized_keys`
   """
   @spec add_authorized_key(String.t()) :: :ok
-  def add_authorized_key(name \\ :default, key) when is_binary(key) do
+  def add_authorized_key(name \\ NervesSSH, key) when is_binary(key) do
     GenServer.call(via_name(name), {:add_authorized_key, key})
   end
 
@@ -72,7 +68,7 @@ defmodule NervesSSH do
   This will also attempt to remove the key in `{USER_DIR}/authorized_keys`
   """
   @spec remove_authorized_key(String.t()) :: :ok
-  def remove_authorized_key(name \\ :default, key) when is_binary(key) do
+  def remove_authorized_key(name \\ NervesSSH, key) when is_binary(key) do
     GenServer.call(via_name(name), {:remove_authorized_key, key})
   end
 
@@ -83,7 +79,7 @@ defmodule NervesSSH do
   authentication for this user
   """
   @spec add_user(String.t(), String.t() | nil) :: :ok
-  def add_user(name \\ :default, user, password) do
+  def add_user(name \\ NervesSSH, user, password) do
     GenServer.call(via_name(name), {:add_user, [user, password]})
   end
 
@@ -91,7 +87,7 @@ defmodule NervesSSH do
   Remove a user credential from the SSH daemon
   """
   @spec remove_user(String.t()) :: :ok
-  def remove_user(name \\ :default, user) do
+  def remove_user(name \\ NervesSSH, user) do
     GenServer.call(via_name(name), {:remove_user, [user]})
   end
 

--- a/lib/nerves_ssh/application.ex
+++ b/lib/nerves_ssh/application.ex
@@ -23,14 +23,15 @@ defmodule NervesSSH.Application do
   @impl Application
   def start(_type, _args) do
     children =
-      case Application.get_all_env(:nerves_ssh) do
-        [] ->
-          # No app environment, so don't start
-          []
+      [{Registry, keys: :unique, name: NervesSSH.Registry}] ++
+        case Application.get_all_env(:nerves_ssh) do
+          [] ->
+            # No app environment, so don't start
+            []
 
-        app_env ->
-          [{NervesSSH, Options.with_defaults(app_env)}]
-      end
+          app_env ->
+            [{NervesSSH, {:default, Options.with_defaults(app_env)}}]
+        end
 
     opts = [strategy: :one_for_one, name: NervesSSH.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/nerves_ssh/application.ex
+++ b/lib/nerves_ssh/application.ex
@@ -30,7 +30,7 @@ defmodule NervesSSH.Application do
             []
 
           app_env ->
-            [{NervesSSH, {:default, Options.with_defaults(app_env)}}]
+            [{NervesSSH, Options.with_defaults(app_env)}]
         end
 
     opts = [strategy: :one_for_one, name: NervesSSH.Supervisor]

--- a/lib/nerves_ssh/keys.ex
+++ b/lib/nerves_ssh/keys.ex
@@ -11,8 +11,13 @@ defmodule NervesSSH.Keys do
   end
 
   @impl :ssh_server_key_api
-  def is_auth_key(key, _user, _options) do
+  def is_auth_key(key, _user, options) do
+    # https://www.erlang.org/doc/man/ssh_server_key_api.html#type-daemon_key_cb_options
+    name =
+      Keyword.fetch!(options, :key_cb_private)
+      |> Keyword.fetch!(:name)
+
     # If any of them match, then we're good.
-    Enum.member?(NervesSSH.configuration().decoded_authorized_keys, key)
+    Enum.member?(NervesSSH.configuration(name).decoded_authorized_keys, key)
   end
 end

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -41,7 +41,7 @@ defmodule NervesSSH.Options do
           daemon_option_overrides: keyword()
         }
 
-  defstruct name: :default,
+  defstruct name: NervesSSH,
             authorized_keys: [],
             decoded_authorized_keys: [],
             user_passwords: [],

--- a/lib/nerves_ssh/user_passwords.ex
+++ b/lib/nerves_ssh/user_passwords.ex
@@ -8,18 +8,24 @@ defmodule NervesSSH.UserPasswords do
 
   require Logger
 
-  @spec check(:erlang.string(), :erlang.string(), :ssh.ip_port(), :undefined | non_neg_integer()) ::
+  @spec check(
+          name :: any(),
+          :erlang.string(),
+          :erlang.string(),
+          :ssh.ip_port(),
+          :undefined | non_neg_integer()
+        ) ::
           boolean() | :disconnect | {boolean, non_neg_integer()}
-  def check(user, password, ip, :undefined), do: check(user, password, ip, 0)
+  def check(name, user, password, ip, :undefined), do: check(name, user, password, ip, 0)
 
-  def check(user, pwd, ip_port, attempt) do
+  def check(name, user, pwd, ip_port, attempt) do
     attempt = attempt + 1
 
-    is_authorized?(user, pwd) || maybe_disconnect(attempt, user, ip_port)
+    is_authorized?(name, user, pwd) || maybe_disconnect(attempt, user, ip_port)
   end
 
-  defp is_authorized?(user, pwd) do
-    NervesSSH.configuration().user_passwords
+  defp is_authorized?(name, user, pwd) do
+    NervesSSH.configuration(name).user_passwords
     |> Enum.find_value(false, fn {u, p} ->
       "#{u}" == "#{user}" and "#{p}" == "#{pwd}"
     end)

--- a/test/nerves_ssh/application_test.exs
+++ b/test/nerves_ssh/application_test.exs
@@ -1,0 +1,58 @@
+defmodule NervesSSH.ApplicationTest do
+  # as starting and stopping the application interferes with other tests using the
+  # NervesSSH.Registry, we must run these tests synchronously
+  use ExUnit.Case, async: false
+
+  @rsa_public_key String.trim(File.read!("test/fixtures/good_user_dir/id_rsa.pub"))
+
+  defp ssh_run(cmd) do
+    ssh_options = [
+      ip: '127.0.0.1',
+      port: 2222,
+      user_interaction: false,
+      silently_accept_hosts: true,
+      save_accepted_host: false,
+      user: 'test_user',
+      password: 'password',
+      user_dir: Path.absname("test/fixtures/good_user_dir")
+    ]
+
+    # Short sleep to make sure server is up an running
+    Process.sleep(200)
+
+    with {:ok, conn} <- SSHEx.connect(ssh_options) do
+      SSHEx.run(conn, cmd)
+    end
+  end
+
+  @tag :has_good_sshd_exec
+  test "stopping and starting the application" do
+    # The application is running, but without a config. Stop
+    # it, so that we can set a config and have it autostart.
+    assert :ok == Application.stop(:nerves_ssh)
+
+    Application.put_all_env([
+      {:nerves_ssh,
+       port: 2222,
+       authorized_keys: [@rsa_public_key],
+       user_dir: Path.absname("test/fixtures/system_dir"),
+       system_dir: Path.absname("test/fixtures/system_dir")}
+    ])
+
+    assert :ok == Application.start(:nerves_ssh)
+    Process.sleep(25)
+    assert {:ok, ":started_once?", 0} == ssh_run(":started_once?")
+
+    assert :ok == Application.stop(:nerves_ssh)
+    Process.sleep(25)
+    assert {:error, :econnrefused} == ssh_run(":really_stopped?")
+
+    assert :ok == Application.start(:nerves_ssh)
+    Process.sleep(25)
+    assert {:ok, ":started_again?", 0} == ssh_run(":started_again?")
+
+    assert :ok == Application.stop(:nerves_ssh)
+    Application.put_all_env(nerves_ssh: [])
+    Process.sleep(25)
+  end
+end


### PR DESCRIPTION
Hello there,

while creating [nerves_ssh_shell](https://github.com/SteffenDE/nerves_ssh_shell) to connect to regular shells on nerves devices, I found the need to start multiple ssh daemons (as ssh subsystems do not allow the same set of features than running a separate daemon). As I also did not want to reimplement what nerves_ssh is already doing very well, I thought that adding the possibility to run multiple daemons seems like something that might benefit others too.

This is not complete yet, for example I only changed the tests to pass for now and did not add new tests for starting multiple daemons, as I first of all wanted some feedback what you all think about this. I also added a configuration option for the used `ssh_cli` setting, but this might not be needed as there is already the `daemon_option_overrides`.