### PR TITLE
Protect system and user dirs used for daemon

### DIFF
--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -245,7 +245,20 @@ defmodule NervesSSH.Options do
   end
 
   defp authentication_daemon_opts(opts) do
-    [system_dir: to_charlist(opts.system_dir), user_dir: to_charlist(opts.user_dir)]
+    [system_dir: safe_dir(opts.system_dir), user_dir: safe_dir(opts.user_dir)]
+  end
+
+  defp safe_dir(dir) do
+    case File.mkdir_p(dir) do
+      :ok ->
+        to_charlist(dir)
+
+      {:error, err} ->
+        tmp = Path.join("/tmp/nerves_ssh", dir)
+        _ = File.mkdir_p(tmp)
+        Logger.warn("[NervesSSH] File error #{inspect(err)} for #{dir} - Using #{tmp}")
+        to_charlist(tmp)
+    end
   end
 
   defp subsystem_opts(opts) do

--- a/test/nerves_ssh/options_test.exs
+++ b/test/nerves_ssh/options_test.exs
@@ -26,11 +26,12 @@ defmodule NervesSSH.OptionsTest do
     opts = Options.new()
     daemon_options = Options.daemon_options(opts)
 
+    assert opts.system_dir == "/data/nerves_ssh"
+    assert opts.user_dir == "/data/nerves_ssh/default_user"
     assert opts.port == 22
 
     assert_options(daemon_options, [
       {:id_string, :random},
-      {:system_dir, '/data/nerves_ssh'},
       # {:shell, {Elixir.IEx, :start, [[dot_iex_path: @dot_iex_path]]}},
       # {:exec, &start_exec/3},
       {:subsystems, [:ssh_sftpd.subsystem_spec(cwd: '/')]},
@@ -245,5 +246,19 @@ defmodule NervesSSH.OptionsTest do
 
       assert File.exists?(Path.join(sys_dir, "ssh_host_rsa_key"))
     end
+  end
+
+  test "system and user dirs default to /tmp when not existing" do
+    sys = "/tmp/some-system"
+    user = "/tmp/some-user"
+    File.touch(sys)
+    File.touch(user)
+    opts = Options.new(system_dir: sys, user_dir: user)
+    daemon_options = Options.daemon_options(opts)
+
+    assert_options(daemon_options, [
+      {:system_dir, '/tmp/nerves_ssh/tmp/some-system'},
+      {:user_dir, '/tmp/nerves_ssh/tmp/some-user'}
+    ])
   end
 end


### PR DESCRIPTION
Fixes #82

In some cases, the filesystem may not be up (or not working) and could case errors
when trying to generate the host key or do anything with the fs. The hope here is
that at least a tmpfs will be up and to try that instead of crashing everything
since Erlang `:ssh` module requires the `system_dir` and `user_dir` option and
there seems to be no way around that (yet?)