### PR TITLE
only add ssh_subsystem_fwup to options if it is not present

### DIFF
--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -75,7 +75,7 @@ defmodule NervesSSH.Options do
   def with_defaults(opts \\ []) do
     opts
     |> new()
-    |> add_fwup_subsystem()
+    |> maybe_add_fwup_subsystem()
     |> sanitize()
   end
 
@@ -302,11 +302,20 @@ defmodule NervesSSH.Options do
 
   defp valid_subsystem?(_), do: false
 
-  defp add_fwup_subsystem(opts) do
-    devpath = KV.get("nerves_fw_devpath")
+  defp maybe_add_fwup_subsystem(opts) do
+    found =
+      Enum.find(opts.subsystems, fn
+        {'fwup', _} -> true
+        _ -> false
+      end)
 
-    new_subsystems = [SSHSubsystemFwup.subsystem_spec(devpath: devpath) | opts.subsystems]
-    %{opts | subsystems: new_subsystems}
+    if found do
+      opts
+    else
+      devpath = KV.get("nerves_fw_devpath")
+      new_subsystems = [SSHSubsystemFwup.subsystem_spec(devpath: devpath) | opts.subsystems]
+      %{opts | subsystems: new_subsystems}
+    end
   end
 
   # :public_key.ssh_decode/2 was deprecated in OTP 24 and will be removed in OTP 26.

--- a/test/nerves_ssh/options_test.exs
+++ b/test/nerves_ssh/options_test.exs
@@ -42,6 +42,19 @@ defmodule NervesSSH.OptionsTest do
     assert map_size(key_cb_private[:host_keys]) > 0
   end
 
+  test "fwup subsystem can be changed" do
+    subsystem = {'fwup', {SSHSubsystemFwup, []}}
+
+    opts =
+      Options.with_defaults(
+        subsystems: [
+          subsystem
+        ]
+      )
+
+    assert opts.subsystems == [subsystem]
+  end
+
   test "Options.new/1 shows user dot_iex_path" do
     opts = Options.new(iex_opts: [dot_iex_path: "/my/iex.exs"])
     assert opts.iex_opts[:dot_iex_path] == "/my/iex.exs"


### PR DESCRIPTION
Fixes a bug where if one supplies ssh subsystem fwup in config.exs, it gets ignored.
Example:

```elixir
config :nerves_ssh,
  system_dir: "/tmp/nerves_ssh",
  subsystems: [{'fwup', {SSHSubsystemFwup, [task: "complete", devpath: "/dev/mmcblk1"]}}]
```

Signed-off-by: Connor Rigby <connorr@hey.com>