### PR TITLE
Drop support for Elixir 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,5 @@ workflows:
                 1.13.4-erlang-25.3.2-alpine-3.18.0,
                 1.13.4-erlang-24.3.4.11-alpine-3.18.0,
                 1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-                1.11.4-erlang-23.3.4.18-alpine-3.16.2,
-                1.10.4-erlang-23.3.4.18-alpine-3.16.2
+                1.11.4-erlang-23.3.4.18-alpine-3.16.2
               ]

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesSSH.MixProject do
     [
       app: :nerves_ssh,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
Nerves requires Elixir >= 1.11.2, so this brings NervesSSh in sync with that and also aids in supporting Elixir 1.15

Fixes #112 