### PR TITLE
Fix LFE warnings when not using LFE

### DIFF
--- a/lib/nerves_ssh/exec.ex
+++ b/lib/nerves_ssh/exec.ex
@@ -32,8 +32,12 @@ defmodule NervesSSH.Exec do
   """
   @spec run_lfe(charlist()) :: {:ok, iolist()} | {:error, binary()}
   def run_lfe(cmd) do
-    {value, _} = :lfe_shell.run_string(cmd)
-    {:ok, :lfe_io.prettyprint1(value, 30)}
+    # Apply is used here since LFE is an optional dependency and we don't want
+    # compiler warnings when it's not being used
+    #
+    # credo:disable-for-lines:2
+    {value, _} = apply(:lfe_shell, :run_string, [cmd])
+    {:ok, apply(:lfe_io, :prettyprint1, [value, 30])}
   catch
     kind, value ->
       {:error, Exception.format(kind, value, __STACKTRACE__)}


### PR DESCRIPTION
This fixes the following warnings:

```
==> nerves_ssh
Compiling 5 files (.ex)
warning: :lfe_io.prettyprint1/2 is undefined (module :lfe_io is not available or is yet to be defined)
  lib/nerves_ssh/exec.ex:36

warning: :lfe_shell.run_string/1 is undefined (module :lfe_shell is not available or is yet to be defined)
  lib/nerves_ssh/exec.ex:35
```
