### PR TITLE
Add name option to docs and specs

### DIFF
--- a/lib/nerves_ssh.ex
+++ b/lib/nerves_ssh.ex
@@ -13,6 +13,14 @@ defmodule NervesSSH do
   # some time to recover.
   @cool_off_time 500
 
+  @typedoc """
+  A name used to refer to a NervesSSH-managed SSH daemon
+
+  This is only needed when running multiple daemons. The default is `NervesSSH`.
+  """
+  @type name() :: any()
+  @default_name NervesSSH
+
   @dialyzer [{:no_opaque, handle_continue: 2}]
 
   @typedoc false
@@ -34,8 +42,8 @@ defmodule NervesSSH do
   @doc """
   Read the configuration options
   """
-  @spec configuration :: Options.t()
-  def configuration(name \\ NervesSSH) do
+  @spec configuration(name()) :: Options.t()
+  def configuration(name \\ @default_name) do
     GenServer.call(via_name(name), :configuration)
   end
 
@@ -44,8 +52,8 @@ defmodule NervesSSH do
 
   See [ssh.daemon_info/1](http://erlang.org/doc/man/ssh.html#daemon_info-1).
   """
-  @spec info() :: {:ok, keyword()} | {:error, :bad_daemon_ref}
-  def info(name \\ NervesSSH) do
+  @spec info(name()) :: {:ok, keyword()} | {:error, :bad_daemon_ref}
+  def info(name \\ @default_name) do
     GenServer.call(via_name(name), :info)
   end
 
@@ -54,8 +62,8 @@ defmodule NervesSSH do
 
   This will also attempt to save the key in `{USER_DIR}/authorized_keys`
   """
-  @spec add_authorized_key(String.t()) :: :ok
-  def add_authorized_key(name \\ NervesSSH, key) when is_binary(key) do
+  @spec add_authorized_key(name(), String.t()) :: :ok
+  def add_authorized_key(name \\ @default_name, key) when is_binary(key) do
     GenServer.call(via_name(name), {:add_authorized_key, key})
   end
 
@@ -64,8 +72,8 @@ defmodule NervesSSH do
 
   This will also attempt to remove the key in `{USER_DIR}/authorized_keys`
   """
-  @spec remove_authorized_key(String.t()) :: :ok
-  def remove_authorized_key(name \\ NervesSSH, key) when is_binary(key) do
+  @spec remove_authorized_key(name(), String.t()) :: :ok
+  def remove_authorized_key(name \\ @default_name, key) when is_binary(key) do
     GenServer.call(via_name(name), {:remove_authorized_key, key})
   end
 
@@ -75,16 +83,16 @@ defmodule NervesSSH do
   Setting password to `""` or `nil` will effectively be passwordless
   authentication for this user
   """
-  @spec add_user(String.t(), String.t() | nil) :: :ok
-  def add_user(name \\ NervesSSH, user, password) do
+  @spec add_user(name(), String.t(), String.t() | nil) :: :ok
+  def add_user(name \\ @default_name, user, password) do
     GenServer.call(via_name(name), {:add_user, [user, password]})
   end
 
   @doc """
   Remove a user credential from the SSH daemon
   """
-  @spec remove_user(String.t()) :: :ok
-  def remove_user(name \\ NervesSSH, user) do
+  @spec remove_user(name(), String.t()) :: :ok
+  def remove_user(name \\ @default_name, user) do
     GenServer.call(via_name(name), {:remove_user, [user]})
   end
 

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -4,6 +4,7 @@ defmodule NervesSSH.Options do
 
   The following fields are available:
 
+  * `:name` - a name used to reference the SSH daemon when running multiple daemons. Defaults to `NervesSSH`.
   * `:authorized_keys` - a list of SSH authorized key file string
   * `:port` - the TCP port to use for the SSH daemon. Defaults to `22`.
   * `:subsystems` - a list of [SSH subsystems specs](https://erlang.org/doc/man/ssh.html#type-subsystem_spec) to start. Defaults to SFTP and `ssh_subsystem_fwup`
@@ -27,7 +28,7 @@ defmodule NervesSSH.Options do
   @type language :: :elixir | :erlang | :lfe | :disabled
 
   @type t :: %__MODULE__{
-          name: any(),
+          name: NervesSSH.name(),
           authorized_keys: [String.t()],
           decoded_authorized_keys: [:public_key.public_key()],
           user_passwords: [{String.t(), String.t()}],


### PR DESCRIPTION
The hex docs weren't showing the specs for any of the public API
functions due to the name parameter not being included in the specs.
