### PR TITLE
Remove process registry for tracking daemons

### DIFF
--- a/lib/nerves_ssh/application.ex
+++ b/lib/nerves_ssh/application.ex
@@ -23,15 +23,14 @@ defmodule NervesSSH.Application do
   @impl Application
   def start(_type, _args) do
     children =
-      [{Registry, keys: :unique, name: NervesSSH.Registry}] ++
-        case Application.get_all_env(:nerves_ssh) do
-          [] ->
-            # No app environment, so don't start
-            []
+      case Application.get_all_env(:nerves_ssh) do
+        [] ->
+          # No app environment, so don't start
+          []
 
-          app_env ->
-            [{NervesSSH, Options.with_defaults(app_env)}]
-        end
+        app_env ->
+          [{NervesSSH, Options.with_defaults(app_env)}]
+      end
 
     opts = [strategy: :one_for_one, name: NervesSSH.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -4,7 +4,7 @@ defmodule NervesSSH.Options do
 
   The following fields are available:
 
-  * `:name` - a name used to reference the SSH daemon when running multiple daemons. Defaults to `NervesSSH`.
+  * `:name` - a name used to reference the NervesSSH-managed SSH daemon. Defaults to `NervesSSH`.
   * `:authorized_keys` - a list of SSH authorized key file string
   * `:port` - the TCP port to use for the SSH daemon. Defaults to `22`.
   * `:subsystems` - a list of [SSH subsystems specs](https://erlang.org/doc/man/ssh.html#type-subsystem_spec) to start. Defaults to SFTP and `ssh_subsystem_fwup`
@@ -28,7 +28,7 @@ defmodule NervesSSH.Options do
   @type language :: :elixir | :erlang | :lfe | :disabled
 
   @type t :: %__MODULE__{
-          name: NervesSSH.name(),
+          name: GenServer.name(),
           authorized_keys: [String.t()],
           decoded_authorized_keys: [:public_key.public_key()],
           user_passwords: [{String.t(), String.t()}],

--- a/test/nerves_ssh/application_test.exs
+++ b/test/nerves_ssh/application_test.exs
@@ -1,6 +1,5 @@
 defmodule NervesSSH.ApplicationTest do
-  # as starting and stopping the application interferes with other tests using the
-  # NervesSSH.Registry, we must run these tests synchronously
+  # These tests modify the global application environment so they can't be run concurrently
   use ExUnit.Case, async: false
 
   @rsa_public_key String.trim(File.read!("test/fixtures/good_user_dir/id_rsa.pub"))

--- a/test/nerves_ssh_test.exs
+++ b/test/nerves_ssh_test.exs
@@ -77,7 +77,7 @@ defmodule NervesSSHTest do
     start_supervised!({NervesSSH, nerves_ssh_config()})
 
     # Test we can send SSH command
-    state = :sys.get_state({:via, Registry, {NervesSSH.Registry, NervesSSH}})
+    state = :sys.get_state(NervesSSH)
     assert {:ok, "2", 0} == ssh_run("1 + 1")
 
     # Simulate sshd failure. restart
@@ -85,7 +85,7 @@ defmodule NervesSSHTest do
     Process.sleep(800)
 
     # Test recovery
-    new_state = :sys.get_state({:via, Registry, {NervesSSH.Registry, NervesSSH}})
+    new_state = :sys.get_state(NervesSSH)
     assert state.sshd != new_state.sshd
 
     assert {:ok, "4", 0} == ssh_run("2 + 2")


### PR DESCRIPTION
Most users only run one SSH daemon so keeping a process registry around
for one entry is overkill. This change requires users to use atoms for
starting more than one daemon. Either that or they could wrap NervesSSH
and use via names to a custom process registry if they really wanted
this ability.
