### PR TITLE
Support Elixir 1.18 :dot_iex option

### DIFF
--- a/test/fixtures/iex.exs
+++ b/test/fixtures/iex.exs
@@ -1,0 +1,1 @@
+# Empty file to support unit tests


### PR DESCRIPTION
The `:dot_iex_path` option changed to `:dot_iex` in Elixir 1.18. Since
NervesSSH was using the old option name, running the `iex.exs` file when
logging in stopped working.

This adds support for the new option name in Elixir 1.18 and normalizes
whatever the users passes in to work right on the version of Elixir that
they're using.

See https://github.com/elixir-lang/elixir/pull/13647 for the links and
discussion about this update.
