### PR TITLE
Add/remove subsystems at runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ tags: &tags
     1.17.3-erlang-27.2-alpine-3.20.3,
     1.16.3-erlang-26.2.5-alpine-3.20.0,
     1.15.7-erlang-26.2.1-alpine-3.18.4,
-    1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-24.3.4.11-alpine-3.18.0
+    1.14.5-erlang-25.3.2-alpine-3.18.0
   ]
 
 jobs:

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -128,6 +128,22 @@ defmodule NervesSSH.Options do
   end
 
   @doc """
+  Add a subsystem
+  """
+  @spec add_subsystem(t(), :ssh.subsystem_spec()) :: t()
+  def add_subsystem(opts, subsystem_spec) do
+    %__MODULE__{opts | subsystems: Enum.uniq_by([subsystem_spec | opts.subsystems], &elem(&1, 0))}
+  end
+
+  @doc """
+  Remove a subsystem
+  """
+  @spec remove_subsystem(t(), charlist()) :: t()
+  def remove_subsystem(opts, subsystem_name) do
+    %__MODULE__{opts | subsystems: Enum.reject(opts.subsystems, &(elem(&1, 0) == subsystem_name))}
+  end
+
+  @doc """
   Load authorized keys from the authorized_keys file
   """
   @spec load_authorized_keys(t()) :: t()

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule NervesSSH.MixProject do
       app: :nerves_ssh,
       version: @version,
       elixir: "~> 1.13",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),
@@ -31,6 +32,9 @@ defmodule NervesSSH.MixProject do
       mod: {NervesSSH.Application, []}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesSSH.MixProject do
     [
       app: :nerves_ssh,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/nerves_ssh/options_test.exs
+++ b/test/nerves_ssh/options_test.exs
@@ -300,4 +300,27 @@ defmodule NervesSSH.OptionsTest do
       {:user_dir, ~c"/tmp/nerves_ssh/tmp/some-user"}
     ])
   end
+
+  test "add/remove subsystems" do
+    opts = Options.new()
+
+    # Add a subsystem
+    sftp_subsystem = {~c"sftp", {:ssh_sftpd, [cwd: ~c"/"]}}
+    opts = Options.add_subsystem(opts, sftp_subsystem)
+    assert opts.subsystems == [sftp_subsystem]
+
+    # Add with different options
+    sftp_subsystem = {~c"sftp", {:ssh_sftpd, [cwd: ~c"/tmp"]}}
+    opts = Options.add_subsystem(opts, sftp_subsystem)
+    assert opts.subsystems == [sftp_subsystem]
+
+    # Add a different subsystem
+    fwup_subsystem = {~c"fwup", SSHSubsystemFwup.subsystem_spec()}
+    opts = Options.add_subsystem(opts, fwup_subsystem)
+    assert opts.subsystems == [fwup_subsystem, sftp_subsystem]
+
+    # Remove a subsystem
+    opts = Options.remove_subsystem(opts, ~c"sftp")
+    assert opts.subsystems == [fwup_subsystem]
+  end
 end

--- a/test/support/echo_subsystem.ex
+++ b/test/support/echo_subsystem.ex
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 Frank Hunleth
+# SPDX-FileCopyrightText: 2025 Ben Youngblood
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule Support.EchoSubsystem do
+  @moduledoc false
+
+  @behaviour :ssh_client_channel
+
+  @impl :ssh_client_channel
+  def init(opts) do
+    {:ok, %{id: nil, cm: nil, prefix: opts[:prefix] || ""}}
+  end
+
+  @impl :ssh_client_channel
+  def handle_msg({:ssh_channel_up, channel_id, cm}, state) do
+    {:ok, %{state | id: channel_id, cm: cm}}
+  end
+
+  @impl :ssh_client_channel
+  def handle_ssh_msg({:ssh_cm, _cm, {:data, _channel_id, type, data}}, state) do
+    # Echo back the data received
+    :ssh_connection.send(state.cm, state.id, type, state.prefix <> data)
+    {:ok, state}
+  end
+
+  @impl :ssh_client_channel
+  def handle_call(_request, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  @impl :ssh_client_channel
+  def handle_cast(_request, state) do
+    {:noreply, state}
+  end
+
+  @impl :ssh_client_channel
+  def code_change(_oldVsn, state, _extra) do
+    {:ok, state}
+  end
+
+  @impl :ssh_client_channel
+  def terminate(_reason, _state) do
+    :ok
+  end
+end


### PR DESCRIPTION
Adds `NervesSSH.add_subsystem/2` and `NervesSSH.remove_system/2` for
managing subsystems at runtime.