### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # NervesSSH
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_ssh.svg "Hex version")](https://hex.pm/packages/nerves_ssh)
-[![API docs](https://img.shields.io/hexpm/v/nerves_ssh.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_ssh/NervesSSH.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_ssh.svg?label=hexdocs "API docs")](https://nerves-ssh.hexdocs.pm/NervesSSH.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/nerves_ssh/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/nerves_ssh/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_ssh)](https://api.reuse.software/info/github.com/nerves-project/nerves_ssh)
 
@@ -219,7 +219,7 @@ If you are migrating from `:nerves_firmware_ssh`, or updating to `:nerves_pack
    updates)
 5. After the new firmware with `:nerves_ssh` is on the device, then you'll need
    to generate the new `upload.sh` script with `mix firmware.gen.script`, or see
-   [SSHSubsystemFwup](https://hexdocs.pm/ssh_subsystem_fwup/readme.html) for
+   [SSHSubsystemFwup](https://ssh-subsystem-fwup.hexdocs.pm/readme.html) for
    other supported options
 
 ## Goals

--- a/lib/nerves_ssh/application.ex
+++ b/lib/nerves_ssh/application.ex
@@ -18,7 +18,7 @@ defmodule NervesSSH.Application do
     This is probably not right. If you recently upgraded to :nerves_ssh or
     a library that uses it like :nerves_pack, you'll need to edit your config.exs
     and rename references to :nerves_firmware_ssh to :nerves_ssh. See
-    https://hexdocs.pm/nerves_ssh/readme.html#configuration.
+    https://nerves-ssh.hexdocs.pm/readme.html#configuration.
 
     To use both :nerves_ssh and :nerves_firmware_ssh simultaneously, supply a
     :nerves_ssh config to bypass this error.


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-ssh.hexdocs.pm/NervesSSH.html): Status 404
❌ Verification failed for https://ssh-subsystem-fwup.hexdocs.pm/readme.html): Status 404
⚠️ Verification finished: 1 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>