### PR TITLE
Add per-connection terminal capability detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 # Changelog
 
+## Unreleased
+
+* New features
+  * Per-connection terminal capability detection. At the start of each
+    interactive Elixir session, NervesSSH can query the connecting terminal for
+    modern feature support (Kitty graphics, sixel, Kitty keyboard protocol,
+    synchronized output, terminal name/version) and expose the results to code
+    running in the session via `NervesSSH.TerminalCapabilities.get/0`. Enabled by
+    default; configurable with the `:detect_terminal_capabilities` option.
+    Requires the Elixir shell on Elixir 1.17+.
+
 ## v1.3.0
 
 This release completely removes support for the SCP protocol. This shouldn't

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ NervesSSH supports the following configuration items:
 * `:exec` - the language to use for commands sent over ssh (`:elixir`,
   `:erlang`, `lfe`, or `:disabled`). Defaults to `:elixir`.
 * `:iex_opts` - additional options to use when starting up IEx
+* `:detect_terminal_capabilities` - query the connecting terminal for modern
+  feature support at the start of each interactive session. `true` (default),
+  `false`, or a keyword list of options (e.g. `[timeout: 1000]`). See
+  [Terminal capabilities](#terminal-capabilities).
 * `:daemon_option_overrides` - additional options to pass to `:ssh.daemon/2`.
   These take precedence and are unchecked. Be careful using this since it can
   break other options. MFAs may be used instead of function refs for OTP 28+.
@@ -132,6 +136,57 @@ Host nerves.local
     UserKnownHostsFile /dev/null
     StrictHostKeyChecking no
 ```
+
+## Terminal capabilities
+
+Modern terminals support far more than VT100: inline images (the
+[Kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/)
+and sixel), the Kitty keyboard protocol, synchronized output, and so on. The
+usual way to detect these — sniffing `TERM`/`KITTY_PID`/`TERM_PROGRAM` — doesn't
+work on a Nerves device: those environment variables live on your laptop, not on
+the device, and they don't survive the hop over SSH.
+
+Instead, NervesSSH can detect capabilities *per connection* by querying the
+terminal directly. At the start of each interactive session — before the IEx
+prompt appears — it sends a batch of capability queries terminated by a Primary
+Device Attributes (DA1) request and reads the responses back over the pty. DA1
+is answered by essentially every terminal and responses arrive in order, so its
+reply doubles as a "we're done" sentinel.
+
+This is on by default. Disable it, or tune the response timeout, with the
+`:detect_terminal_capabilities` option:
+
+```elixir
+config :nerves_ssh,
+  # ...
+  detect_terminal_capabilities: [timeout: 1000]
+  # or `false` to turn it off
+```
+
+Code running inside a session can read what was detected:
+
+```elixir
+iex> NervesSSH.TerminalCapabilities.get()
+%NervesSSH.TerminalCapabilities{
+  queried?: true,
+  term: "kitty(0.32.0)",
+  primary_da: "62;4",
+  sixel: true,
+  kitty_graphics: true,
+  kitty_keyboard: true,
+  synchronized_output: true,
+  raw: "..."
+}
+```
+
+Use this to decide, for example, whether to render a QR code or chart inline
+with the Kitty graphics protocol or fall back to ASCII. If the terminal doesn't
+answer (or detection is disabled), `get/0` returns a struct with `queried?:
+true` and all features `false`, or `nil` respectively, and nothing is printed to
+the session.
+
+When detection is enabled, a terminal that doesn't respond adds at most one
+`:timeout` (default 500 ms) to session startup.
 
 ## Authentication
 

--- a/lib/nerves_ssh/application.ex
+++ b/lib/nerves_ssh/application.ex
@@ -27,7 +27,7 @@ defmodule NervesSSH.Application do
 
   @impl Application
   def start(_type, _args) do
-    children =
+    daemon_children =
       case Application.get_all_env(:nerves_ssh) do
         [] ->
           # No app environment, so don't start
@@ -36,6 +36,11 @@ defmodule NervesSSH.Application do
         app_env ->
           [{NervesSSH, Options.with_defaults(app_env)}]
       end
+
+    # The capability registry is cheap and tracks per-session terminal features
+    # for any NervesSSH daemon (including ones started outside the app env), so
+    # always run it.
+    children = [NervesSSH.TerminalCapabilities.Registry | daemon_children]
 
     opts = [strategy: :one_for_one, name: NervesSSH.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/nerves_ssh/options.ex
+++ b/lib/nerves_ssh/options.ex
@@ -21,6 +21,11 @@ defmodule NervesSSH.Options do
   * `:shell` - the language of the shell (`:elixir`, `:erlang`, `:lfe` or `:disabled`). Defaults to `:elixir`.
   * `:exec` - the language to use for commands sent over ssh (`:elixir`, `:erlang`, or `:disabled`). Defaults to `:elixir`.
   * `:iex_opts` - additional options to use when starting up IEx
+  * `:detect_terminal_capabilities` - whether to query the connecting terminal
+    for modern feature support (Kitty graphics, sixel, etc.) at the start of each
+    interactive session. `true` (default), `false`, or a keyword list of options
+    passed to `NervesSSH.TerminalCapabilities.detect/1` (e.g. `[timeout: 1000]`).
+    Only applies to the Elixir shell on Elixir 1.17+.
   * `:user_passwords` - a list of username/password tuples (stored in the clear!)
   * `:daemon_option_overrides` - additional options to pass to `:ssh.daemon/2`. These take precedence and are unchecked. Be careful using this since it can break other options.
   """
@@ -52,6 +57,7 @@ defmodule NervesSSH.Options do
           shell: language(),
           exec: language(),
           iex_opts: keyword(),
+          detect_terminal_capabilities: boolean() | keyword(),
           daemon_option_overrides: keyword()
         }
 
@@ -66,6 +72,7 @@ defmodule NervesSSH.Options do
             shell: :elixir,
             exec: :elixir,
             iex_opts: [{@dot_iex_option, Path.expand(".iex.exs")}],
+            detect_terminal_capabilities: true,
             daemon_option_overrides: []
 
   @doc """
@@ -254,8 +261,8 @@ defmodule NervesSSH.Options do
   end
 
   if Version.match?(System.version(), ">= 1.17.0") do
-    defp shell_opts(%{shell: :elixir, iex_opts: iex_opts}),
-      do: [{:shell, {:iex, :start, [iex_opts, {:elixir_utils, :noop, []}]}}]
+    defp shell_opts(%{shell: :elixir, iex_opts: iex_opts} = opts),
+      do: [{:shell, {:iex, :start, [iex_opts, shell_callback(opts)]}}]
   else
     defp shell_opts(%{shell: :elixir, iex_opts: iex_opts}),
       do: [{:shell, {Elixir.IEx, :start, [iex_opts]}}]
@@ -264,6 +271,19 @@ defmodule NervesSSH.Options do
   defp shell_opts(%{shell: :erlang}), do: []
   defp shell_opts(%{shell: :lfe}), do: [{:shell, {:lfe_shell, :start, []}}]
   defp shell_opts(%{shell: :disabled}), do: [shell: :disabled]
+
+  # The IEx shell-startup callback runs once, before the prompt, with the
+  # session's terminal as its group leader. We use it to detect terminal
+  # capabilities; otherwise fall back to the upstream no-op.
+  defp shell_callback(%{detect_terminal_capabilities: false}),
+    do: {:elixir_utils, :noop, []}
+
+  defp shell_callback(%{detect_terminal_capabilities: detect_opts})
+       when is_list(detect_opts),
+       do: {NervesSSH.TerminalCapabilities, :detect_callback, [detect_opts]}
+
+  defp shell_callback(%{detect_terminal_capabilities: _truthy}),
+    do: {NervesSSH.TerminalCapabilities, :detect_callback, [[]]}
 
   defp exec_opts(%{exec: :elixir}), do: [exec: {:direct, &NervesSSH.Exec.run_elixir/1}]
   defp exec_opts(%{exec: :erlang}), do: []

--- a/lib/nerves_ssh/terminal_capabilities.ex
+++ b/lib/nerves_ssh/terminal_capabilities.ex
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2025 Lars Wikman
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesSSH.TerminalCapabilities do
+  @moduledoc """
+  Per-connection detection of modern terminal features.
+
+  When an interactive SSH session starts, NervesSSH can query the connecting
+  terminal for the features it supports and remember the answers for the life of
+  that session. Unlike `TERM`/environment sniffing (which doesn't survive the
+  hop onto a Nerves device), this works by sending escape-sequence *queries* and
+  reading the terminal's *responses* back over the SSH pty.
+
+  Detection happens in the `t:IEx` shell-startup callback, before the prompt is
+  shown, so it adds at most one `:timeout` (default #{500} ms) to session
+  startup when the terminal doesn't answer.
+
+  ## Querying from inside a session
+
+      iex> NervesSSH.TerminalCapabilities.get()
+      %NervesSSH.TerminalCapabilities{
+        queried?: true,
+        kitty_graphics: true,
+        sixel: false,
+        ...
+      }
+
+  Use this to decide, e.g., whether to render an inline image with the Kitty
+  graphics protocol or fall back to ASCII.
+
+  ## Detection technique
+
+  Queries are sent as a single batch, terminated by a Primary Device Attributes
+  (DA1, `ESC [ c`) request. DA1 is supported by essentially every terminal and
+  responses arrive in order, so the DA1 reply doubles as a "we're done"
+  sentinel: anything that was going to answer has answered by the time it
+  arrives. See https://github.com/sindresorhus/terminal-query for the same idea.
+  """
+
+  alias NervesSSH.TerminalCapabilities.Registry
+
+  @default_timeout 500
+
+  defstruct queried?: false,
+            term: nil,
+            primary_da: nil,
+            sixel: false,
+            kitty_graphics: false,
+            kitty_keyboard: false,
+            synchronized_output: false,
+            raw: nil
+
+  @type t :: %__MODULE__{
+          queried?: boolean(),
+          term: String.t() | nil,
+          primary_da: String.t() | nil,
+          sixel: boolean(),
+          kitty_graphics: boolean(),
+          kitty_keyboard: boolean(),
+          synchronized_output: boolean(),
+          raw: binary() | nil
+        }
+
+  @doc """
+  Return the capabilities detected for the current SSH session, or `nil` if none
+  were detected (e.g. detection was disabled or this isn't an SSH session).
+  """
+  @spec get() :: t() | nil
+  def get() do
+    Registry.lookup(Process.group_leader())
+  end
+
+  @doc """
+  Shell-startup callback. Detects capabilities for the current session's
+  terminal and stores them in the registry.
+
+  This is used as the `IEx` startup callback (see
+  `NervesSSH.Options`). It must never crash: a non-normal exit here would
+  prevent the IEx prompt from starting.
+  """
+  @spec detect_callback(keyword()) :: :ok
+  def detect_callback(opts \\ []) do
+    caps = detect(opts)
+    Registry.track(Process.group_leader(), caps)
+    :ok
+  catch
+    kind, reason ->
+      require Logger
+
+      Logger.warning(
+        "[NervesSSH] terminal capability detection failed: #{inspect({kind, reason})}"
+      )
+
+      :ok
+  end
+
+  @doc """
+  Query the terminal behind `device` (default: the current group leader) and
+  return its capabilities.
+
+  Options:
+
+    * `:device` - the IO device / group leader to query. Defaults to
+      `Process.group_leader/0`.
+    * `:timeout` - total milliseconds to wait for responses. Defaults to
+      `#{@default_timeout}`.
+  """
+  @spec detect(keyword()) :: t()
+  def detect(opts \\ []) do
+    device = Keyword.get(opts, :device) || Process.group_leader()
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    # echo off -> the Erlang `group` routes input through its "dumb" state where
+    # get_chars returns bytes immediately instead of waiting for a newline.
+    # binary -> read raw bytes rather than charlists.
+    :ok = :io.setopts(device, [{:echo, false}, {:binary, true}])
+
+    try do
+      :ok = :io.put_chars(device, queries())
+      device |> read_until_da(timeout) |> parse()
+    after
+      # Restore what the IEx prompt expects.
+      _ = :io.setopts(device, [{:echo, true}, {:binary, false}])
+    end
+  end
+
+  # Sent as one batch. DA1 (ESC[c) MUST be last so its reply is the sentinel.
+  defp queries() do
+    IO.iodata_to_binary([
+      # XTVERSION: terminal name + version
+      "\e[>q",
+      # Kitty keyboard protocol: query progressive enhancement flags
+      "\e[?u",
+      # DECRQM: synchronized output (mode 2026)
+      "\e[?2026$p",
+      # Kitty graphics: a no-op query image (a=q) -> replies ";OK" if supported
+      "\e_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\e\\",
+      # Primary Device Attributes (sentinel + sixel detection)
+      "\e[c"
+    ])
+  end
+
+  # Read one byte at a time until the DA1 reply terminates the buffer or we time
+  # out. A separate reader process does the blocking reads and streams bytes
+  # back, so a terminal that never answers can't block us past the deadline.
+  defp read_until_da(device, timeout) do
+    parent = self()
+    reader = spawn(fn -> reader_loop(device, parent) end)
+    deadline = System.monotonic_time(:millisecond) + timeout
+    acc = collect(deadline, <<>>)
+    Process.exit(reader, :kill)
+    acc
+  end
+
+  defp reader_loop(device, parent) do
+    case IO.getn(device, "", 1) do
+      <<b>> ->
+        send(parent, {:byte, b})
+        reader_loop(device, parent)
+
+      :eof ->
+        send(parent, :eof)
+
+      _other ->
+        reader_loop(device, parent)
+    end
+  end
+
+  defp collect(deadline, acc) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      acc
+    else
+      receive do
+        {:byte, b} ->
+          acc = acc <> <<b>>
+          if da_reply?(acc), do: acc, else: collect(deadline, acc)
+
+        :eof ->
+          acc
+      after
+        remaining -> acc
+      end
+    end
+  end
+
+  # True once the accumulated buffer ends with a complete DA1 reply: ESC [ ? … c
+  defp da_reply?(buf), do: Regex.match?(~r/\x1b\[\?[0-9;]*c\z/, buf)
+
+  @doc false
+  @spec parse(binary()) :: t()
+  def parse(raw) do
+    %__MODULE__{
+      queried?: true,
+      raw: raw,
+      primary_da: capture(raw, ~r/\x1b\[\?([0-9;]*)c/),
+      term: capture(raw, ~r/\x1bP>\|([^\x1b]*)\x1b\\/),
+      sixel: sixel?(raw),
+      kitty_graphics: Regex.match?(~r/\x1b_G[^\x1b]*;OK/, raw),
+      kitty_keyboard: Regex.match?(~r/\x1b\[\?\d+u/, raw),
+      synchronized_output: synchronized_output?(raw)
+    }
+  end
+
+  # Sixel is advertised as attribute "4" in the DA1 parameter list.
+  defp sixel?(raw) do
+    case capture(raw, ~r/\x1b\[\?([0-9;]*)c/) do
+      nil -> false
+      params -> "4" in String.split(params, ";")
+    end
+  end
+
+  # DECRPM reply: ESC [ ? 2026 ; <value> $ y. value 1 (set) or 2 (reset) means
+  # the mode is recognized/supported; 0 (not recognized) or 4 (permanently
+  # reset) means it isn't.
+  defp synchronized_output?(raw) do
+    case capture(raw, ~r/\x1b\[\?2026;(\d+)\$y/) do
+      value when value in ["1", "2"] -> true
+      _ -> false
+    end
+  end
+
+  defp capture(raw, regex) do
+    case Regex.run(regex, raw) do
+      [_, captured] -> captured
+      _ -> nil
+    end
+  end
+end

--- a/lib/nerves_ssh/terminal_capabilities/registry.ex
+++ b/lib/nerves_ssh/terminal_capabilities/registry.ex
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 Lars Wikman
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesSSH.TerminalCapabilities.Registry do
+  @moduledoc """
+  Stores per-connection terminal capabilities.
+
+  Capabilities are keyed by the SSH session's group leader pid (the Erlang
+  `group` process that backs the pty). Code running inside an SSH session shares
+  that group leader, so it can look its own capabilities up with
+  `NervesSSH.TerminalCapabilities.get/0`.
+
+  The group leader is monitored so that the entry is removed automatically when
+  the session ends.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Store capabilities for the given group leader and monitor it for cleanup.
+  """
+  @spec track(pid(), struct()) :: :ok
+  def track(group_leader, caps) when is_pid(group_leader) do
+    GenServer.cast(__MODULE__, {:track, group_leader, caps})
+  end
+
+  @doc """
+  Look up the capabilities for a group leader. Returns `nil` if unknown or if
+  the registry isn't running.
+  """
+  @spec lookup(pid()) :: struct() | nil
+  def lookup(group_leader) when is_pid(group_leader) do
+    case :ets.whereis(@table) do
+      :undefined ->
+        nil
+
+      tid ->
+        case :ets.lookup(tid, group_leader) do
+          [{^group_leader, caps}] -> caps
+          [] -> nil
+        end
+    end
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    table = :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    {:ok, %{table: table, monitors: %{}}}
+  end
+
+  @impl GenServer
+  def handle_cast({:track, group_leader, caps}, state) do
+    :ets.insert(@table, {group_leader, caps})
+
+    monitors =
+      Map.put_new_lazy(state.monitors, group_leader, fn ->
+        Process.monitor(group_leader)
+      end)
+
+    {:noreply, %{state | monitors: monitors}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    :ets.delete(@table, pid)
+    {:noreply, %{state | monitors: Map.delete(state.monitors, pid)}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+end

--- a/test/nerves_ssh/terminal_capabilities_test.exs
+++ b/test/nerves_ssh/terminal_capabilities_test.exs
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2025 Lars Wikman
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesSSH.TerminalCapabilitiesTest do
+  use ExUnit.Case, async: false
+
+  alias NervesSSH.TerminalCapabilities
+
+  @system_dir Path.absname("test/fixtures/system_dir")
+
+  # A kitty-class terminal's answers to the detection batch, in query order.
+  @kitty_bundle IO.iodata_to_binary([
+                  # XTVERSION
+                  "\eP>|kitty(0.32.0)\e\\",
+                  # kitty keyboard flags
+                  "\e[?1u",
+                  # DECRPM synchronized output: 2 = reset/supported
+                  "\e[?2026;2$y",
+                  # kitty graphics ok
+                  "\e_Gi=31;OK\e\\",
+                  # DA1: 62 = VT220, 4 = sixel
+                  "\e[?62;4c"
+                ])
+
+  describe "parse/1" do
+    test "parses a full kitty-class response" do
+      caps = TerminalCapabilities.parse(@kitty_bundle)
+
+      assert caps.queried?
+      assert caps.term == "kitty(0.32.0)"
+      assert caps.primary_da == "62;4"
+      assert caps.sixel
+      assert caps.kitty_graphics
+      assert caps.kitty_keyboard
+      assert caps.synchronized_output
+    end
+
+    test "a plain DA1-only response detects nothing extra" do
+      caps = TerminalCapabilities.parse("\e[?62c")
+
+      assert caps.queried?
+      assert caps.primary_da == "62"
+      refute caps.sixel
+      refute caps.kitty_graphics
+      refute caps.kitty_keyboard
+      refute caps.synchronized_output
+    end
+
+    test "sixel is taken from DA1 attribute 4" do
+      assert TerminalCapabilities.parse("\e[?62;4;6c").sixel
+      refute TerminalCapabilities.parse("\e[?62;22c").sixel
+    end
+
+    test "synchronized output requires a recognized DECRPM value" do
+      assert TerminalCapabilities.parse("\e[?2026;1$y\e[?62c").synchronized_output
+      assert TerminalCapabilities.parse("\e[?2026;2$y\e[?62c").synchronized_output
+      # 0 = not recognized, 4 = permanently reset
+      refute TerminalCapabilities.parse("\e[?2026;0$y\e[?62c").synchronized_output
+      refute TerminalCapabilities.parse("\e[?2026;4$y\e[?62c").synchronized_output
+    end
+
+    test "an empty response (terminal didn't answer) is queried but all-false" do
+      caps = TerminalCapabilities.parse("")
+      assert caps.queried?
+      assert caps.primary_da == nil
+      refute caps.kitty_graphics
+    end
+  end
+
+  describe "per-connection detection over SSH" do
+    setup %{line: line} do
+      # The capability registry normally lives in the :nerves_ssh app
+      # supervision tree, but ApplicationTest stops the app and leaves it
+      # stopped. Make sure the registry is up regardless of test ordering.
+      unless Process.whereis(NervesSSH.TerminalCapabilities.Registry) do
+        start_supervised!(NervesSSH.TerminalCapabilities.Registry)
+      end
+
+      port = 4500 + line
+      {:ok, port: port}
+    end
+
+    test "detects a kitty-class terminal and exposes it to the session", %{port: port} do
+      start_daemon(port, true)
+      result = run_session(port, answer: @kitty_bundle)
+      assert result == "kg=true,sx=true,q=true"
+    end
+
+    test "a non-responding terminal yields queried? with no features", %{port: port} do
+      start_daemon(port, timeout: 300)
+      result = run_session(port, answer: nil)
+      assert result == "kg=false,sx=false,q=true"
+    end
+
+    test "detection can be disabled", %{port: port} do
+      start_daemon(port, false)
+      result = run_session(port, answer: nil)
+      assert result == "none"
+    end
+  end
+
+  # --- helpers ---
+
+  defp start_daemon(port, detect) do
+    opts =
+      NervesSSH.Options.with_defaults(
+        user_passwords: [{"u", "p"}],
+        system_dir: @system_dir,
+        user_dir: @system_dir,
+        port: port,
+        detect_terminal_capabilities: detect
+      )
+
+    start_supervised!({NervesSSH, opts})
+    # let the daemon bind
+    Process.sleep(150)
+  end
+
+  # Connect, allocate a pty, start the shell, optionally answer the detection
+  # query batch, then drive the IEx prompt to print the detected capabilities.
+  defp run_session(port, opts) do
+    answer = Keyword.get(opts, :answer)
+
+    {:ok, conn} =
+      :ssh.connect(~c"127.0.0.1", port, [
+        {:user, ~c"u"},
+        {:password, ~c"p"},
+        {:user_interaction, false},
+        {:silently_accept_hosts, true},
+        {:save_accepted_host, false}
+      ])
+
+    {:ok, ch} = :ssh_connection.session_channel(conn, 5000)
+    :success = :ssh_connection.ptty_alloc(conn, ch, [{:term, ~c"xterm-kitty"}])
+    :ok = :ssh_connection.shell(conn, ch)
+
+    # "RESULT" and the value text are assembled at runtime so they never appear
+    # in the command's local echo -- only in the real output.
+    # `\#{...}` keeps the interpolation literal here so it runs on the *remote*
+    # IEx, not at compile time. `\r` submits the line via the SSH line editor.
+    cmd =
+      "IO.puts(\"RES\" <> \"ULT\" <> \":\" <> (case NervesSSH.TerminalCapabilities.get() do nil -> \"none\"; c -> \"kg=\#{c.kitty_graphics},sx=\#{c.sixel},q=\#{c.queried?}\" end))\r"
+
+    state = %{acc: "", answer: answer, answered: false, sent_cmd: false, cmd: cmd}
+    out = drive(conn, ch, state, 10_000)
+    :ssh.close(conn)
+    out
+  end
+
+  defp drive(conn, ch, state, timeout) do
+    receive do
+      {:ssh_cm, ^conn, {:data, ^ch, _type, data}} ->
+        state = %{state | acc: state.acc <> data}
+        state = maybe_answer(conn, ch, state)
+        state = maybe_send_cmd(conn, ch, state)
+
+        case extract_result(state.acc) do
+          nil -> drive(conn, ch, state, timeout)
+          result -> result
+        end
+
+      {:ssh_cm, ^conn, {:closed, ^ch}} ->
+        extract_result(state.acc) || {:closed, state.acc}
+
+      {:ssh_cm, ^conn, _other} ->
+        drive(conn, ch, state, timeout)
+    after
+      timeout -> {:timeout, extract_result(state.acc), state.acc}
+    end
+  end
+
+  # Respond to the DA1 query (end of the detection batch) once.
+  defp maybe_answer(conn, ch, %{answered: false} = state) do
+    if String.contains?(state.acc, "\e[c") do
+      if is_binary(state.answer), do: :ssh_connection.send(conn, ch, 0, state.answer)
+      %{state | answered: true}
+    else
+      state
+    end
+  end
+
+  defp maybe_answer(_conn, _ch, state), do: state
+
+  # Once the IEx prompt appears, send the probe command once.
+  defp maybe_send_cmd(conn, ch, %{sent_cmd: false} = state) do
+    if String.contains?(state.acc, "iex(") do
+      :ssh_connection.send(conn, ch, 0, state.cmd)
+      %{state | sent_cmd: true}
+    else
+      state
+    end
+  end
+
+  defp maybe_send_cmd(_conn, _ch, state), do: state
+
+  defp extract_result(acc) do
+    case Regex.run(~r/RESULT:([^\r\n]*)/, acc) do
+      [_, payload] -> payload
+      _ -> nil
+    end
+  end
+end


### PR DESCRIPTION
Lars' notes:

This is an experiment towards supporting modern terminal features over SSH. I'm not sure it is worthwhile since it raises a lot of fun compat concerns.

I was mostly interested in if it was possible to get some of this feature-set over SSH and in Elixir. Perhaps being able to detect support for the kitty image protocol and other fun madness.

Claude:

Detect modern terminal features (Kitty graphics, sixel, Kitty keyboard protocol, synchronized output, terminal name/version) per SSH connection by querying the connecting terminal and reading its responses back over the pty.

Environment-based detection (TERM/KITTY_PID/TERM_PROGRAM) doesn't work on a Nerves device: those variables live on the client and don't survive the hop over SSH. Instead, the IEx shell-startup callback runs a batch of capability queries terminated by a Primary Device Attributes (DA1) request. Reading with echo off routes input through the Erlang group's "dumb" state, where get_chars returns bytes immediately rather than waiting for a newline, so the raw response can be read without a custom ssh_cli. DA1 is answered by essentially every terminal and responses arrive in order, so its reply doubles as a completion sentinel.

Results are stored per session (keyed by group leader, cleaned up on disconnect) and exposed via NervesSSH.TerminalCapabilities.get/0. Controlled by the new :detect_terminal_capabilities option (default on; Elixir 1.17+).